### PR TITLE
do not push to remote when nothing has changed

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -28,5 +28,8 @@ find . -mindepth 1 -and \
 
 cp -a ../build/html/* .
 git add -A
-git commit -m "autocommit by publish.sh"
-git push origin master
+if git commit -m "autocommit by publish.sh"; then
+  git push origin master
+else
+  echo "Nothing to commit: website is up-to-date."
+fi


### PR DESCRIPTION
Current `publish.sh` pushes to remote when nothing has changed, causing the shell script to exit with error (status 1). This becomes problem when running `./publish.sh` from Jenkins. This pull-req fixes the problem.
