### PR TITLE
(hotfix) fix syntax error and typo (fix #94)

### DIFF
--- a/source/en/faq_rpc_err_workaround.rst
+++ b/source/en/faq_rpc_err_workaround.rst
@@ -47,7 +47,7 @@ Ruby
 + When RPC methods mismatching, type mismatching errors occur by RPC, ``Jubatus::Common::InterfaceMismatch`` exception will be raised.
   When algorithm errors occur by RPC, ``MessagePack::RPC::RemoteError`` or ``MessagePack::RPC::CallError`` exception will be raised.
   You should catch these exceptions and close sessions explicitly.
-  You can catch any RPC exceptions by ``RPCError``  excluding ``TrasportError`` and ``TimeoutError`` .
+  You can catch any RPC exceptions by ``RPCError``  excluding ``TransportError`` and ``TimeoutError`` .
 
 .. code-block:: ruby
 

--- a/source/ja/faq_rpc_err_workaround.rst
+++ b/source/ja/faq_rpc_err_workaround.rst
@@ -46,7 +46,7 @@ Ruby
 
 + RPC呼び出しで、メソッド名や型の不一致が発生した場合は ``Jubatus::Common::InterfaceMismatch`` 例外が発生します。
   アルゴリズムのエラーが発生した場合は ``MessagePack::RPC::RemoteError`` または ``MessagePack::RPC::CallError`` 例外が発生します。
-  これらの例外を捕捉し、接続を明示的に破棄します。 ``TrasportError`` および ``TimeoutError``以外の ``RPCError`` をまとめて捕捉してもよいでしょう。
+  これらの例外を捕捉し、接続を明示的に破棄します。 ``TransportError`` および ``TimeoutError`` 以外の ``RPCError`` をまとめて捕捉してもよいでしょう。
 
 .. code-block:: ruby
 


### PR DESCRIPTION
Fix #94.

Reason why we need to treat this pull-req as hotfix:
- typo
