### PR TITLE
(hotfix) Rename keeper to proxy in en/tutorial_distributed.rst

### DIFF
--- a/source/en/tutorial_distributed.rst
+++ b/source/en/tutorial_distributed.rst
@@ -66,7 +66,7 @@ Jubatus proxies proxy RPC requests from clients to servers.
 In distributed environment, make RPC requests from clients to proxies, not directly to servers.
 
 Jubatus proxies are provided for each Jubatus servers.
-For the classifier, ``jubaclassifier_keeper`` is the corresponding proxy.
+For the classifier, ``jubaclassifier_proxy`` is the corresponding proxy.
 
 ::
 


### PR DESCRIPTION
I found `jubaclassifier_keeper` in en/tutorial_distributed.rst.
It's renamed to `jubaclassifier_proxy` in version 0.5.0 .
