### PR TITLE
(hotfix) Write about annotations of common methods

### DIFF
--- a/source/en/server.rst
+++ b/source/en/server.rst
@@ -99,7 +99,7 @@ The following RPC methods for server are automatically appended to each service 
 
 .. code-block:: c++
 
-  #@random #@analysis
+  #@random #@analysis #@pass
   string get_config()
 
   #@broadcast #@analysis #@all_and

--- a/source/ja/server.rst
+++ b/source/ja/server.rst
@@ -99,7 +99,7 @@ RPC インターフェースは `MessagePack-IDL <https://github.com/msgpack/msg
 
 .. code-block:: c++
 
-  #@random #@analysis
+  #@random #@analysis #@pass
   string get_config()
 
   #@broadcast #@analysis #@all_and


### PR DESCRIPTION
In https://github.com/jubatus/website/issues/87, I said like followings:

> common RPC methods (save, load ..) are not defined in IDL. So, user can not know Lock-type easily (Other than to read source code *_impl.cpp).
> 
> How about adding Lock-type in Client API page?

But, I reconsidered that there is no need to document about Lock-type of each common methods.

Then instead, I described that "Annotations of common methods are specified by jenerator" in server.html
