### PR TITLE
document options to disable MIX trigger

### DIFF
--- a/source/en/commands.rst
+++ b/source/en/commands.rst
@@ -92,11 +92,15 @@ Jubatus server provides the machine learning feature.
 
    Invoke "mix" in every ``<seconds>`` second. [16]
 
+   Specifying ``0`` disables time-based mix invocation.
+
 .. option:: -i <count>, --interval_count <count>
 
    Invoke "mix" in every ``<count>`` updates. [512]
 
    The update is counted when API that updates the training model (such as ``train`` in the classifier) is called.
+
+   Specifying ``0`` disables update-based mix invocation.
 
 .. option:: -Z <seconds>, --zookeeper_timeout <seconds>
 

--- a/source/ja/commands.rst
+++ b/source/ja/commands.rst
@@ -92,11 +92,15 @@ Jubatus サーバは機械学習の機能を提供する。
 
    毎 ``<seconds>`` 秒おきに mix を行う。 [16]
 
+   ``0`` を指定すると、時間契機での mix の起動を行わない。
+
 .. option:: -i <count>, --interval_count <count>
 
    毎 ``<count>`` 更新ごとに mix を行う。 [512]
 
    更新カウントは、学習モデルを更新する API (分類器の ``train`` など) を呼ぶたびにインクリメントされる。
+
+   ``0`` を指定すると、更新契機での mix の起動を行わない。
 
 .. option:: -Z <seconds>, --zookeeper_timeout <seconds>
 


### PR DESCRIPTION
Document behavior of MIX-trigger-related options implemented in https://github.com/jubatus/jubatus/pull/623, and must be ready for 0.5.1.
