### PR TITLE
(Hotfix) Use version range specification for pom.xml (fixes #112)

### DIFF
--- a/source/en/quickstart.rst
+++ b/source/en/quickstart.rst
@@ -157,7 +157,7 @@ Please add these lines to ``pom.xml`` of your project.
      <dependency>
        <groupId>us.jubat</groupId>
        <artifactId>jubatus</artifactId>
-       <version>0.5.1</version>
+       <version>[0.5,)</version>
      </dependency>
    </dependencies>
 

--- a/source/ja/quickstart.rst
+++ b/source/ja/quickstart.rst
@@ -157,7 +157,7 @@ Java
      <dependency>
        <groupId>us.jubat</groupId>
        <artifactId>jubatus</artifactId>
-       <version>0.5.1</version>
+       <version>[0.5,)</version>
      </dependency>
    </dependencies>
 


### PR DESCRIPTION
I changed pom.xml to use latest 0.5.x clients.
- [F.Y.I] Version Range Specification: http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
