### PR TITLE
python 3 support

### DIFF
--- a/source/en/quickstart.rst
+++ b/source/en/quickstart.rst
@@ -121,7 +121,7 @@ For Ubuntu systems, type:
 Python
 ~~~~~~
 
-The client (requires Python 2.6 or 2.7) is available in `PyPI <http://pypi.python.org/pypi/jubatus>`_.
+The client (requires Python 2.6, 2.7 or 3.x) is available in `PyPI <http://pypi.python.org/pypi/jubatus>`_.
 
 ::
 

--- a/source/ja/quickstart.rst
+++ b/source/ja/quickstart.rst
@@ -121,7 +121,7 @@ Ubuntu では、以下のコマンドを実行します。
 Python
 ~~~~~~
 
-クライアント (Python 2.6 または 2.7 が必要) は `PyPI <http://pypi.python.org/pypi/jubatus>`_ で配布されています。
+クライアント (Python 2.6, 2.7 または 3.x が必要) は `PyPI <http://pypi.python.org/pypi/jubatus>`_ で配布されています。
 
 ::
 


### PR DESCRIPTION
Clarify that Python 3 is officially supported.