### PR TITLE
support Ubuntu 14.04 LTS

### DIFF
--- a/source/en/quickstart.rst
+++ b/source/en/quickstart.rst
@@ -5,7 +5,7 @@ Quick Start
 Install Jubatus
 ---------------
 
-We officially support Red Hat Enterprise Linux (RHEL) 6.2 or later (64-bit) and Ubuntu Server 12.04 LTS (64-bit).
+We officially support Red Hat Enterprise Linux (RHEL) 6.2 or later (64-bit) and Ubuntu Server 12.04 LTS / 14.04 LTS (64-bit).
 On supported systems, you can install all components of Jubatus using binary packages.
 
 Other Linux distributions (including 32-bit) and Mac OS X are experimentally supported.
@@ -40,14 +40,18 @@ If the installation command above fails with the missing ``oniguruma`` package e
   // For RHEL 6 systems that cannot find oniguruma package (and rhel-6-server-optional-rpms is unavailable)
   $ sudo yum --enablerepo=jubatus-optional install jubatus jubatus-client
 
-Ubuntu Server 12.04 LTS (64-bit)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ubuntu Server (64-bit)
+~~~~~~~~~~~~~~~~~~~~~~
 
 Write the following line to ``/etc/apt/sources.list.d/jubatus.list`` to register Jubatus Apt repository to the system.
 
 ::
 
-  deb http://download.jubat.us/apt binary/
+  // For Ubuntu 12.04 (Precise)
+  deb http://download.jubat.us/apt/ubuntu/precise binary/
+
+  // For Ubuntu 14.04 (Trusty)
+  deb http://download.jubat.us/apt/ubuntu/trusty binary/
 
 Now install ``jubatus`` package.
 
@@ -65,7 +69,7 @@ Bypass the warning by answering ``y`` to the prompt when asked:
 
 Now Jubatus is installed in ``/opt/jubatus``.
 
-Each time before using Jubatus, you need to load the environment variable from ``profile`` script.
+Each time before using Jubatus, you need to load the environment variable from ``profile`` script (you can add the line to ``~/.bash_profile``).
 
 ::
 

--- a/source/ja/quickstart.rst
+++ b/source/ja/quickstart.rst
@@ -5,7 +5,7 @@
 Jubatus のインストール
 ----------------------
 
-Red Hat Enterprise Linux (RHEL) 6.2 以降 (64-bit) と Ubuntu Server 12.04 LTS (64-bit) を公式にサポートしています。
+Red Hat Enterprise Linux (RHEL) 6.2 以降 (64-bit) と Ubuntu Server 12.04 LTS / 14.04  (64-bit) を公式にサポートしています。
 これらのシステムでは、Jubatus のすべてのコンポーネントをバイナリパッケージでインストールすることができます。
 
 また、その他の Linux 環境 (32-bit を含む) と Mac OS X が試験的にサポートされています。
@@ -40,14 +40,18 @@ RHEL 6 では、依存パッケージ (``oniguruma``) のインストールに `
   // RHEL 6 で、oniguruma パッケージが存在しない場合 (rhel-6-server-optional-rpms が利用できない場合)
   $ sudo yum --enablerepo=jubatus-optional install jubatus jubatus-client
 
-Ubuntu Server 12.04 LTS (64-bit)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ubuntu Server (64-bit)
+~~~~~~~~~~~~~~~~~~~~~~
 
 以下の行を ``/etc/apt/sources.list.d/jubatus.list`` に記述して、Jubatus の Apt リポジトリをシステムに登録します。
 
 ::
 
-  deb http://download.jubat.us/apt binary/
+  // Ubuntu 12.04 (Precise) の場合
+  deb http://download.jubat.us/apt/ubuntu/precise binary/
+
+  // Ubuntu 14.04 (Trusty) の場合
+  deb http://download.jubat.us/apt/ubuntu/trusty binary/
 
 ``jubatus`` のパッケージをインストールします。
 
@@ -65,7 +69,7 @@ Ubuntu Server 12.04 LTS (64-bit)
 
 これで、Jubatus が ``/opt/jubatus`` にインストールされました。
 
-Jubatus を使う前に、毎回 ``profile`` スクリプトから環境変数を読み込む必要があります。
+Jubatus を使う前に、毎回 ``profile`` スクリプトから環境変数を読み込む必要があります (``~/.bash_profile`` に追記しておくと便利です)。
 
 ::
 


### PR DESCRIPTION
We have separated the repository URL to maintain packages for two Ubuntu releases.

Old repository URL is going to point 12.04 repos, so that existing users are not affected.