### PR TITLE
Remove broken link

### DIFF
--- a/source/en/developers/howtocontribute.rst
+++ b/source/en/developers/howtocontribute.rst
@@ -40,7 +40,7 @@ Pull-Request Policy
 
 We always welcome your code and/or documentation contributions! Here are some rules:
 
-* Every pull-requests will be reviewed by one (or more) of Jubatus committers. `Reviewers <https://github.com/jubatus/jubatus/wiki/Policy:Reviewers>`_ will be chosen according to the area of the code you contributed.
+* Every pull-requests will be reviewed by one (or more) of Jubatus committers. Reviewers will be chosen according to the area of the code you contributed.
 
 * After the review process, the status of your pull-request will either be:
 

--- a/source/ja/developers/howtocontribute.rst
+++ b/source/ja/developers/howtocontribute.rst
@@ -40,7 +40,7 @@ Pull-Request ポリシー
 
 コード/ドキュメントに対する Pull-Request も歓迎しています。
 
-* Pull-Request はすべて、一人以上の Jubatus コミッタがレビューします。 `レビュアー <https://github.com/jubatus/jubatus/wiki/Policy:Reviewers-(ja)>`_ は担当領域ごとに決められています。
+* Pull-Request はすべて、一人以上の Jubatus コミッタがレビューします。レビュアーは担当領域ごとに決められています。
 
 * レビューが終わると、Pull-Request は次のいずれかの状態になります:
 


### PR DESCRIPTION
In my opinion, Policy:Reviewers page is not found in Jubatus's wiki pages.
I would like to suggest that removing this link.